### PR TITLE
add playbook to install the most recent restic version from github

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ install_zsh: false
 install_docker: false
 install_spotify: false
 install_chrome: false
+install_restic: false
 
 # activate wakemeops - https://docs.wakemeops.com/packages/
 packages_activate_wakemeops_repo: false

--- a/playbooks/restic.yml
+++ b/playbooks/restic.yml
@@ -1,0 +1,38 @@
+---
+- hosts: localhost
+  become: true
+  become_method: sudo
+  tasks:
+    - name: Get latest restic release  # noqa command-instead-of-module
+      ansible.builtin.shell: >
+        set -o pipefail |
+        curl -s -L https://api.github.com/repos/restic/restic/releases/latest
+        | grep -Po '"tag_name": "\K.*?(?=\")' | cut -d"v" -f2
+      register: restic_version
+      changed_when: false
+      failed_when: restic_version.rc != 0
+
+    - name: Download and install ferdium package
+      ansible.builtin.get_url:
+        url: https://github.com/restic/restic/releases/download/v{{ restic_version.stdout }}/restic_{{ restic_version.stdout }}_linux_amd64.bz2
+        dest: /tmp/restic.bz2
+
+    - name: decompress restic
+      ansible.builtin.command: /usr/bin/bunzip2 /tmp/restic.bz2
+
+    - name: move restic file to /usr/local/bin
+      ansible.builtin.copy:
+        remote_src: true
+        src: /tmp/restic
+        dest: /usr/local/bin/restic
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Cleanup temporary files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /tmp/restic.bz2
+        - /tmp/restic

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -30,3 +30,7 @@
 - name: Include chrome playbook
   ansible.builtin.import_playbook: chrome.yml
   when: install_chrome | bool
+
+- name: Include restic playbook
+  ansible.builtin.import_playbook: restic.yml
+  when: install_restic | bool


### PR DESCRIPTION
the playbook checks the github releases for the most recent version and places the binary file in /usr/local/bin.

Afterwards you can update via running the playbook again or running `restic self-update` as root